### PR TITLE
check if cartography columns exist prior to plotting

### DIFF
--- a/celloracle/network_analysis/gene_analysis.py
+++ b/celloracle/network_analysis/gene_analysis.py
@@ -376,7 +376,7 @@ def plot_cartography_term(links, goi, save=None):
     tt.columns = [i.replace("role_", "") for i in tt.columns]
 
     order = ["Ultra peripheral", "Peripheral", "Connector","Kinless","Provincical Hub","Connector Hub", "Kinless Hub"]
-
+    order = [o for o in order if o in tt.columns]
     #print(tt)
     tt = tt.loc[links.palette.index.values, order].fillna(0)
     sns.heatmap(data=tt, cmap="Blues", cbar=False)


### PR DESCRIPTION
Not all links objects have all roles. When a role is missing  links.plot_cartography_term() errors out.
`---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-104-f0d911e6167f> in <module>
      1 # Plot the summary of cartography analysis
----> 2 links.plot_cartography_term(goi="Tcf12", save=f"{save_folder}/cartography")

~/anaconda3/lib/python3.7/site-packages/celloracle/network_analysis/links_object.py in plot_cartography_term(self, goi, save)
    312                Plots will not be saved if [save=None]. Default is None.
    313         """
--> 314         plot_cartography_term(links=self, goi=goi, save=save)
    315 
    316 

~/anaconda3/lib/python3.7/site-packages/celloracle/network_analysis/gene_analysis.py in plot_cartography_term(links, goi, save)
    379 
    380     #print(tt)
--> 381     tt = tt.loc[links.palette.index.values, order].fillna(0)
    382     sns.heatmap(data=tt, cmap="Blues", cbar=False)
    383     if not save is None:

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in __getitem__(self, key)
   1760                 except (KeyError, IndexError, AttributeError):
   1761                     pass
-> 1762             return self._getitem_tuple(key)
   1763         else:
   1764             # we by definition only have the 0th axis

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in _getitem_tuple(self, tup)
   1279         # ugly hack for GH #836
   1280         if self._multi_take_opportunity(tup):
-> 1281             return self._multi_take(tup)
   1282 
   1283         # no shortcut needed

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in _multi_take(self, tup)
   1338         d = {
   1339             axis: self._get_listlike_indexer(key, axis)
-> 1340             for (key, axis) in zip(tup, o._AXIS_ORDERS)
   1341         }
   1342         return o._reindex_with_indexers(d, copy=True, allow_dups=True)

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in <dictcomp>(.0)
   1338         d = {
   1339             axis: self._get_listlike_indexer(key, axis)
-> 1340             for (key, axis) in zip(tup, o._AXIS_ORDERS)
   1341         }
   1342         return o._reindex_with_indexers(d, copy=True, allow_dups=True)

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in _get_listlike_indexer(self, key, axis, raise_missing)
   1551 
   1552         self._validate_read_indexer(
-> 1553             keyarr, indexer, o._get_axis_number(axis), raise_missing=raise_missing
   1554         )
   1555         return keyarr, indexer

~/anaconda3/lib/python3.7/site-packages/pandas/core/indexing.py in _validate_read_indexer(self, key, indexer, axis, raise_missing)
   1653             if not (ax.is_categorical() or ax.is_interval()):
   1654                 raise KeyError(
-> 1655                     "Passing list-likes to .loc or [] with any missing labels "
   1656                     "is no longer supported, see "
   1657                     "https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501

KeyError: 'Passing list-likes to .loc or [] with any missing labels is no longer supported, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike'`

This request checks that the terms in order are present before plotting heatmap. 