### PR TITLE
editing the evaluate_and_plot_simulation_value_distribution function

### DIFF
--- a/celloracle/trajectory/oracle_core.py
+++ b/celloracle/trajectory/oracle_core.py
@@ -964,7 +964,7 @@ class Oracle(modified_VelocytoLoom, Oracle_visualization):
         if save is not None:
             os.makedirs(save, exist_ok=True)
 
-        for goi, val in ood_stats[:4].iterrows():
+        for goi, val in ood_stats[:n_genes].iterrows():
             fig, ax = plt.subplots(figsize=figsize)
             in_range_cell_ratio = 1 - val["OOD_cell_ratio"]
             ax.hist(imputed_count[goi], label="Original value", alpha=alpha, bins=n_bins)


### PR DESCRIPTION
Updated the `evaluate_and_plot_simulation_value_distribution` function within celloracle/trajectory/oracle_core.py to dynamically use the `n_genes` parameter for determining the number of top shifted genes to display. Previously, the display count was incorrectly fixed at 4 within the for loop in function, despite the presence of an `n_genes` argument in the function's definition. 