### PR TITLE
fix biothings_client import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ goatools
 genomepy>=0.8.4
 gimmemotifs>=0.14.4, <=0.17.2
 anndata<=0.10.8
+biothings_client==0.2.6


### PR DESCRIPTION
While following the tutorial and attempting to import celloracle, I encountered an import error caused by the latest version of biothings_client, which is a dependency of genomepy. Below is the error traceback:

```
Python 3.10.16 | packaged by conda-forge | (main, Dec  5 2024, 14:16:10) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import celloracle as co
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/Main/preturb_prediction/dev/CellOracle/celloracle/__init__.py", line 8, in <module>
    from . import utility, network, network_analysis, go_analysis, data, data_conversion, oracle_utility
  File "/home/ubuntu/Main/preturb_prediction/dev/CellOracle/celloracle/utility/__init__.py", line 18, in <module>
    from .load_hdf5 import load_hdf5
  File "/home/ubuntu/Main/preturb_prediction/dev/CellOracle/celloracle/utility/load_hdf5.py", line 8, in <module>
    from ..motif_analysis.tfinfo_core import load_TFinfo
  File "/home/ubuntu/Main/preturb_prediction/dev/CellOracle/celloracle/motif_analysis/__init__.py", line 11, in <module>
    from .motif_analysis_utility import is_genome_installed
  File "/home/ubuntu/Main/preturb_prediction/dev/CellOracle/celloracle/motif_analysis/motif_analysis_utility.py", line 22, in <module>
    from genomepy import Genome
  File "/home/ubuntu/mambaforge/envs/test_celloracle/lib/python3.10/site-packages/genomepy/__init__.py", line 10, in <module>
    from genomepy.annotation import Annotation, query_mygene
  File "/home/ubuntu/mambaforge/envs/test_celloracle/lib/python3.10/site-packages/genomepy/annotation/__init__.py", line 11, in <module>
    from genomepy.annotation.mygene import _map_genes, query_mygene
  File "/home/ubuntu/mambaforge/envs/test_celloracle/lib/python3.10/site-packages/genomepy/annotation/mygene.py", line 4, in <module>
    import mygene
  File "/home/ubuntu/mambaforge/envs/test_celloracle/lib/python3.10/site-packages/mygene/__init__.py", line 6, in <module>
    from biothings_client import alwayslist, get_client
ImportError: cannot import name 'alwayslist' from 'biothings_client' (/home/ubuntu/mambaforge/envs/test_celloracle/lib/python3.10/site-packages/biothings_client/__init__.py)
```


To resolve this issue, I specified a version of biothings_client that includes the alwayslist function. This resolved the import error successfully.

