### PR TITLE
Add version limit to matplotlib-inline.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy
 cython
 numba>=0.50.1
 matplotlib<3.7
+matplotlib-inline<=0.1.7
 seaborn
 scikit-learn
 h5py>=3.1.0


### PR DESCRIPTION
Newest version of matplotlib-inline seems to be incompatible with the version of matplotlib required for CellOracle. This fixes the issue by adding a limit to matplotlib-inline version.